### PR TITLE
Fix to wrong number of args

### DIFF
--- a/hive.el
+++ b/hive.el
@@ -45,10 +45,10 @@
   :type 'sql-login-params
   :group 'SQL)
 
-(defun sql-comint-hive (product options)
+(defun sql-comint-hive (product options &optional buffer)
   "Create comint buffer and connect to Hive."
   (let ((params options))
-    (sql-comint product params)))
+    (sql-comint product params buffer)))
 
 ;;;###autoload
 (defun sql-hive (&optional buffer)


### PR DESCRIPTION
```
sql-product-interactive: Wrong number of arguments: #[(product options) "~A
	\")" [options params product sql-comint] 3
```